### PR TITLE
Add support for Windows builds via vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ option(GPRAT_ENABLE_FORMAT_TARGETS "Enable clang-format / cmake-format targets"
        ${PROJECT_IS_TOP_LEVEL})
 
 if(GPRAT_ENABLE_FORMAT_TARGETS)
+  set(CMAKE_FORMAT_EXCLUDE "^external_ports/")
+
   find_package(format QUIET)
   if(NOT format_FOUND)
     include(FetchContent)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,6 +22,21 @@
       }
     },
     {
+      "name": "vcpkg",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "X_VCPKG_APPLOCAL_DEPS_INSTALL": "ON"
+      }
+    },
+    {
+      "name": "vcpkg-win64-static",
+      "hidden": true,
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x64-windows-static-md-release"
+      }
+    },
+    {
       "name": "cppcheck",
       "hidden": true,
       "cacheVariables": {
@@ -67,7 +82,7 @@
       "description": "Note that all the flags after /W4 are required for MSVC to conform to the language standard",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/sdl /guard:cf /utf-8 /diagnostics:caret /w14165 /w44242 /w44254 /w44263 /w34265 /w34287 /w44296 /w44365 /w44388 /w44464 /w14545 /w14546 /w14547 /w14549 /w14555 /w34619 /w34640 /w24826 /w14905 /w14906 /w14928 /w45038 /W4 /permissive- /volatile:iso /Zc:inline /Zc:preprocessor /Zc:enumTypes /Zc:lambda /Zc:__cplusplus /Zc:externConstexpr /Zc:throwingNew /EHsc",
+        "CMAKE_CXX_FLAGS": "/sdl /guard:cf /utf-8 /diagnostics:caret /w14165 /w44242 /w44254 /w44263 /w34265 /w34287 /w44296 /w44365 /w44388 /w44464 /w14545 /w14546 /w14547 /w14549 /w14555 /w34619 /w34640 /w24826 /w14905 /w14906 /w14928 /w45038 /W4 /permissive- /volatile:iso /Zc:inline /Zc:preprocessor /Zc:enumTypes /Zc:lambda /Zc:__cplusplus /Zc:externConstexpr /Zc:throwingNew /EHsc /D_CRT_SECURE_NO_WARNINGS",
         "CMAKE_EXE_LINKER_FLAGS": "/machine:x64 /guard:cf",
         "CMAKE_SHARED_LINKER_FLAGS": "/machine:x64 /guard:cf"
       }
@@ -146,7 +161,7 @@
     },
     {
       "name": "ci-windows",
-      "inherits": ["ci-build", "ci-win64", "ci-multi-config"]
+      "inherits": ["ci-build", "ci-win64", "ci-multi-config", "vcpkg", "vcpkg-win64-static"]
     },
     {
       "name": "ci-ubuntu-24.04",

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -66,16 +66,13 @@ if(GPRAT_ENABLE_MKL)
   # Link Intel oneMKL
   target_link_libraries(gprat_core PUBLIC MKL::mkl_intel_lp64 MKL::mkl_core
                                           MKL::MKL MKL::mkl_sequential)
+  target_compile_definitions(gprat_core PUBLIC GPRAT_ENABLE_MKL)
 else()
   # Link OpenBLAS
   target_link_libraries(gprat_core PUBLIC ${OpenBLAS_LIB})
 endif()
 
-if(GPRAT_ENABLE_MKL)
-  target_compile_definitions(gprat_core PUBLIC GPRAT_ENABLE_MKL)
-endif()
-
-target_compile_features(gprat_core PUBLIC cxx_std_17)
+target_compile_features(gprat_core PUBLIC cxx_std_20)
 
 set_property(TARGET gprat_core PROPERTY POSITION_INDEPENDENT_CODE ON)
 

--- a/core/src/cpu/gp_algorithms.cpp
+++ b/core/src/cpu/gp_algorithms.cpp
@@ -1,6 +1,7 @@
 #include "cpu/gp_algorithms.hpp"
 
 #include <cmath>
+#include <iterator>
 
 namespace cpu
 {

--- a/core/src/cpu/gp_optimizer.cpp
+++ b/core/src/cpu/gp_optimizer.cpp
@@ -1,6 +1,7 @@
 #include "cpu/gp_optimizer.hpp"
 
 #include "cpu/adapter_cblas_fp64.hpp"
+#include <numbers>
 #include <numeric>
 
 namespace cpu
@@ -212,7 +213,7 @@ double add_losses(const std::vector<double> &losses, std::size_t N, std::size_t 
         l += losses[i];
     }
 
-    l += Nn * log(2.0 * M_PI);
+    l += Nn * log(2.0 * std::numbers::pi);
     return 0.5 * l / Nn;  // why /Nn?
 }
 

--- a/core/src/gp_hyperparameters.cpp
+++ b/core/src/gp_hyperparameters.cpp
@@ -1,6 +1,7 @@
 #include "gp_hyperparameters.hpp"
 
 #include <iomanip>
+#include <sstream>
 
 namespace gprat_hyper
 {

--- a/external_ports/README.md
+++ b/external_ports/README.md
@@ -1,0 +1,3 @@
+# What is this?
+
+This contains custom vcpkg ports and forks of official ones.

--- a/external_ports/intel-mkl/copy-from-dmg.cmake
+++ b/external_ports/intel-mkl/copy-from-dmg.cmake
@@ -1,0 +1,53 @@
+find_program(HDIUTIL NAMES hdiutil REQUIRED)
+set(dmg_path "NOTFOUND" CACHE FILEPATH "Where to find the DMG")
+set(output_dir "output_dir" CACHE FILEPATH "Where to put the packages")
+
+if(NOT EXISTS "${dmg_path}")
+    message(FATAL_ERROR "'dmg_path' (${dmg_path}) does not exist.")
+endif()
+if(NOT IS_DIRECTORY "${output_dir}")
+    message(FATAL_ERROR "'output_dir' (${output_dir}) is not a directory.")
+endif()
+
+execute_process(
+    COMMAND mktemp -d
+    RESULT_VARIABLE mktemp_result
+    OUTPUT_VARIABLE mount_point
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(NOT mktemp_result STREQUAL "0")
+    message(FATAL_ERROR "mktemp -d failed: ${mktemp_result}")
+elseif(NOT IS_DIRECTORY "${mount_point}")
+    message(FATAL_ERROR "'mount_point' (${mount_point}) is not a directory.")
+endif()
+
+execute_process(
+    COMMAND "${HDIUTIL}" attach "${dmg_path}" -mountpoint "${mount_point}" -readonly
+    RESULT_VARIABLE mount_result
+)
+if(mount_result STREQUAL "0")
+    set(dmg_packages_dir "${mount_point}/bootstrapper.app/Contents/Resources/packages")
+    file(GLOB packages
+        "${dmg_packages_dir}/intel.oneapi.mac.mkl.devel,*"
+        "${dmg_packages_dir}/intel.oneapi.mac.mkl.runtime,*"
+        "${dmg_packages_dir}/intel.oneapi.mac.mkl.product,*"
+        "${dmg_packages_dir}/intel.oneapi.mac.openmp,*"
+    )
+    # Using execute_process to avoid direct errors
+    execute_process(
+        COMMAND cp -R ${packages} "${output_dir}/"
+        RESULT_VARIABLE copy_result
+    )
+endif()
+execute_process(
+    COMMAND "${HDIUTIL}" detach "${mount_point}"
+    RESULT_VARIABLE unmount_result
+)
+
+if(NOT mount_result STREQUAL "0")
+    message(FATAL_ERROR "Mounting ${dmg_path} failed: ${mount_result}")
+elseif(NOT copy_result STREQUAL "0")
+    message(FATAL_ERROR "Coyping packages failed: ${copy_result}")
+elseif(NOT unmount_result STREQUAL "0")
+    message(FATAL_ERROR "Unounting ${dmg_path} failed: ${unmount_result}")
+endif()

--- a/external_ports/intel-mkl/portfile.cmake
+++ b/external_ports/intel-mkl/portfile.cmake
@@ -1,0 +1,260 @@
+# This package installs Intel MKL on Linux, macOS and Windows for x64.
+# Configuration:
+#   - ilp64
+#   - dynamic CRT: intel_thread, static CRT: sequential
+
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+# https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19150/w_onemkl_p_2023.0.0.25930_offline.exe # windows
+# https://registrationcenter-download.intel.com/akdlm/IRC_NAS/19116/m_onemkl_p_2023.0.0.25376_offline.dmg # macos
+# https://registrationcenter-download.intel.com/akdlm/irc_nas/19138/l_onemkl_p_2023.0.0.25398_offline.sh # linux
+set(sha "")
+if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+  # nop
+elseif(VCPKG_TARGET_IS_WINDOWS)
+  set(filename w_onemkl_p_2023.0.0.25930_offline.exe)
+  set(magic_number 19150)
+  set(sha a3eb6b75241a2eccb73ed73035ff111172c55d3fa51f545c7542277a155df84ff72fc826621711153e683f84058e64cb549c030968f9f964531db76ca8a3ed46)
+  set(package_infix "win")
+elseif(VCPKG_TARGET_IS_OSX)
+  set(filename m_onemkl_p_2023.0.0.25376_offline.dmg)
+  set(magic_number 19116)
+  set(sha 7b9b8c004054603e6830fb9b9c049d5a4cfc0990c224cb182ac5262ab9f1863775a67491413040e3349c590e2cca58edcfc704db9f3b9f9faa8b5b09022cd2af)
+  set(package_infix "mac")
+  set(package_libdir "lib")
+  set(compiler_libdir "mac/compiler/lib")
+elseif(VCPKG_TARGET_IS_LINUX)
+  set(filename l_onemkl_p_2023.0.0.25398_offline.sh)
+  set(magic_number 19138)
+  set(sha b5f2f464675f0fd969dde2faf2e622b834eb1cc406c4a867148116f6c24ba5c709d98b678840f4a89a1778e12cde0ff70ce2ef59faeef3d3f3aa1d0329c71af1)
+  set(package_infix "lin")
+  set(package_libdir "lib/intel64")
+  set(compiler_libdir "linux/compiler/lib/intel64_lin")
+endif()
+
+if(NOT sha)
+  message(WARNING "${PORT} is empty for ${TARGET_TRIPLET}.")
+  return()
+endif()
+
+vcpkg_download_distfile(installer_path
+    URLS "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/${magic_number}/${filename}"
+    FILENAME "${filename}"
+    SHA512 "${sha}"
+)
+
+# Note: intel_thread and lp64 are the defaults.
+set(interface "ilp64") # or ilp64; ilp == 64 bit int api
+#https://www.intel.com/content/www/us/en/develop/documentation/onemkl-linux-developer-guide/top/linking-your-application-with-onemkl/linking-in-detail/linking-with-interface-libraries/using-the-ilp64-interface-vs-lp64-interface.html
+if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
+    set(threading "intel_thread") #sequential or intel_thread or tbb_thread or pgi_thread
+else()
+    set(threading "sequential")
+endif()
+if(threading STREQUAL "intel_thread")
+    set(short_thread "iomp")
+else()
+    string(SUBSTRING "${threading}" "0" "3" short_thread)
+endif()
+set(main_pc_file "mkl-${VCPKG_LIBRARY_LINKAGE}-${interface}-${short_thread}.pc")
+
+# First extraction level: packages (from offline installer)
+set(extract_0_dir "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-extract")
+file(REMOVE_RECURSE "${extract_0_dir}")
+file(MAKE_DIRECTORY "${extract_0_dir}")
+
+# Second extraction level: actual files (from packages)
+set(extract_1_dir "${CURRENT_PACKAGES_DIR}/intel-extract")
+file(REMOVE_RECURSE "${extract_1_dir}")
+file(MAKE_DIRECTORY "${extract_1_dir}")
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_find_acquire_program(7Z)
+    message(STATUS "Extracting offline installer")
+    vcpkg_execute_required_process(
+        COMMAND "${7Z}" x "${installer_path}" "-o${extract_0_dir}" "-y" "-bso0" "-bsp0"
+        WORKING_DIRECTORY "${extract_0_dir}"
+        LOGNAME "extract-${TARGET_TRIPLET}-0"
+    )
+
+    set(packages 
+        "intel.oneapi.win.mkl.devel,v=2023.0.0-25930/oneapi-mkl-devel-for-installer_p_2023.0.0.25930.msi" # has the required libs. 
+        "intel.oneapi.win.mkl.runtime,v=2023.0.0-25930/oneapi-mkl-for-installer_p_2023.0.0.25930.msi" # has the required DLLs
+        #"intel.oneapi.win.compilers-common-runtime,v=2023.0.0-25922" # SVML
+        "intel.oneapi.win.openmp,v=2023.0.0-25922/oneapi-comp-openmp-for-installer_p_2023.0.0.25922.msi" # OpenMP
+        #"intel.oneapi.win.tbb.runtime,v=2021.8.0-25874" #TBB
+        )
+
+    foreach(pack IN LISTS packages)
+        set(package_path "${extract_0_dir}/packages/${pack}")
+        cmake_path(GET pack STEM LAST_ONLY packstem)
+        cmake_path(NATIVE_PATH package_path package_path_native)
+        vcpkg_execute_required_process(
+            COMMAND "${LESSMSI}" x "${package_path_native}"
+            WORKING_DIRECTORY "${extract_1_dir}" 
+            LOGNAME "extract-${TARGET_TRIPLET}-${packstem}"
+        )
+        file(COPY "${extract_1_dir}/${packstem}/SourceDir/" DESTINATION "${extract_1_dir}")
+        file(REMOVE_RECURSE "${extract_1_dir}/${packstem}")
+    endforeach()
+
+    set(mkl_dir "${extract_1_dir}/Intel/Compiler/12.0/mkl/2023.0.0")
+    file(COPY "${mkl_dir}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    # see https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl-link-line-advisor.html for linking
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+      set(files "mkl_core_dll.lib" "mkl_${threading}_dll.lib" "mkl_intel_${interface}_dll.lib" "mkl_blas95_${interface}.lib" "mkl_lapack95_${interface}.lib") # "mkl_rt.lib" single dynamic lib with dynamic dispatch
+      file(COPY "${mkl_dir}/redist/intel64/" DESTINATION "${CURRENT_PACKAGES_DIR}/bin") # Could probably be reduced instead of copying all
+      if(NOT VCPKG_BUILD_TYPE)
+        file(COPY "${mkl_dir}/redist/intel64/" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+      endif()
+    else()
+      set(files "mkl_core.lib" "mkl_${threading}.lib" "mkl_intel_${interface}.lib" "mkl_blas95_${interface}.lib" "mkl_lapack95_${interface}.lib")
+    endif()
+    foreach(file IN LISTS files)
+      file(COPY "${mkl_dir}/lib/intel64/${file}" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/intel64") # instead of manual-link keep normal structure
+      if(NOT VCPKG_BUILD_TYPE)
+        file(COPY "${mkl_dir}/lib/intel64/${file}" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/intel64")
+      endif()
+    endforeach()
+    file(COPY_FILE "${mkl_dir}/lib/pkgconfig/${main_pc_file}" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}")
+
+    set(compiler_dir "${extract_1_dir}/Intel/Compiler/12.0/compiler/2023.0.0")
+    if(threading STREQUAL "intel_thread")
+      file(COPY "${compiler_dir}/windows/redist/intel64_win/compiler/" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+      file(COPY "${compiler_dir}/windows/compiler/lib/intel64_win/" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/intel64")
+      file(COPY_FILE "${compiler_dir}/lib/pkgconfig/openmp.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libiomp5.pc")
+      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libiomp5.pc" "/windows/compiler/lib/intel64_win/" "/lib/intel64/")
+      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libiomp5.pc" "-I \${includedir}" "-I\"\${includedir}\"")
+      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}" "openmp" "libiomp5")
+      if(NOT VCPKG_BUILD_TYPE)
+        file(COPY "${compiler_dir}/windows/redist/intel64_win/compiler/" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+        file(COPY "${compiler_dir}/windows/compiler/lib/intel64_win/" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/intel64")
+      endif()
+    endif()
+else()
+    message(STATUS "Warning: This port is still a work on progress. 
+   E.g. it is not correctly filtering the libraries in accordance with
+   VCPKG_LIBRARY_LINKAGE. It is using the default threading (Intel OpenMP)
+   which is known to segfault when used together with GNU OpenMP.
+")
+
+    message(STATUS "Extracting offline installer")
+    if(VCPKG_TARGET_IS_LINUX)
+      vcpkg_execute_required_process(
+          COMMAND "bash" "--verbose" "--noprofile" "${installer_path}" "--extract-only" "--extract-folder" "${extract_0_dir}"
+          WORKING_DIRECTORY "${extract_0_dir}"
+          LOGNAME "extract-${TARGET_TRIPLET}-0"
+      )
+      file(RENAME "${extract_0_dir}/l_onemkl_p_2023.0.0.25398_offline/packages" "${extract_0_dir}/packages")
+    elseif(VCPKG_TARGET_IS_OSX)
+      find_program(HDIUTIL NAMES hdiutil REQUIRED)
+      file(MAKE_DIRECTORY "${extract_0_dir}/packages")
+      message(STATUS "... Don't interrupt.")
+      vcpkg_execute_required_process(
+          COMMAND "${CMAKE_COMMAND}" "-Ddmg_path=${installer_path}"
+                                     "-Doutput_dir=${extract_0_dir}/packages"
+                                     "-DHDIUTIL=${HDIUTIL}"
+                                     -P "${CMAKE_CURRENT_LIST_DIR}/copy-from-dmg.cmake"
+          WORKING_DIRECTORY "${extract_0_dir}"
+          LOGNAME "extract-${TARGET_TRIPLET}-0"
+      )
+      message(STATUS "... Done.")
+    endif()
+
+    file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.mkl.runtime,v=2023.0.0-*")
+    cmake_path(GET package_path STEM LAST_ONLY packstem)
+    message(STATUS "Extracting ${packstem}")
+    vcpkg_execute_required_process(
+        COMMAND "${CMAKE_COMMAND}" "-E" "tar" "-xf" "${package_path}/cupPayload.cup"
+            "_installdir/mkl/2023.0.0/lib"
+            "_installdir/mkl/2023.0.0/licensing"
+        WORKING_DIRECTORY "${extract_1_dir}"
+        LOGNAME "extract-${TARGET_TRIPLET}-${packstem}"
+    )
+    file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.mkl.devel,v=2023.0.0-*")
+    cmake_path(GET package_path STEM LAST_ONLY packstem)
+    message(STATUS "Extracting ${packstem}")
+    vcpkg_execute_required_process(
+        COMMAND "${CMAKE_COMMAND}" "-E" "tar" "-xf" "${package_path}/cupPayload.cup"
+            "_installdir/mkl/2023.0.0/bin"
+            "_installdir/mkl/2023.0.0/include"
+            "_installdir/mkl/2023.0.0/lib"
+        WORKING_DIRECTORY "${extract_1_dir}"
+        LOGNAME "extract-${TARGET_TRIPLET}-${packstem}"
+    )
+    file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.openmp,v=2023.0.0-*")
+    cmake_path(GET package_path STEM LAST_ONLY packstem)
+    message(STATUS "Extracting ${packstem}")
+    vcpkg_execute_required_process(
+        COMMAND "${CMAKE_COMMAND}" "-E" "tar" "-xf" "${package_path}/cupPayload.cup"
+            "_installdir/compiler/2023.0.0"
+        WORKING_DIRECTORY "${extract_1_dir}"
+        LOGNAME "extract-${TARGET_TRIPLET}-${packstem}"
+    )
+
+    set(mkl_dir "${extract_1_dir}/_installdir/mkl/2023.0.0")
+    file(COPY "${mkl_dir}/include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    file(COPY "${mkl_dir}/${package_libdir}/" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/intel64")
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+      set(to_remove_suffix .a)
+    elseif(VCPKG_TARGET_IS_OSX)
+      set(to_remove_suffix .dylib)
+    else()
+      set(to_remove_suffix .so)
+    endif()
+    file(GLOB_RECURSE files_to_remove
+        "${CURRENT_PACKAGES_DIR}/lib/intel64/*${to_remove_suffix}"
+        "${CURRENT_PACKAGES_DIR}/lib/intel64/*${to_remove_suffix}.?"
+    )
+    file(REMOVE ${files_to_remove})
+    file(COPY_FILE "${mkl_dir}/lib/pkgconfig/${main_pc_file}" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}" "\${exec_prefix}/${package_libdir}" "\${exec_prefix}/lib/intel64" IGNORE_UNCHANGED)
+  
+    set(compiler_dir "${extract_1_dir}/_installdir/compiler/2023.0.0")
+    if(threading STREQUAL "intel_thread")
+      file(COPY "${compiler_dir}/${compiler_libdir}/" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/intel64")
+      file(COPY_FILE "${compiler_dir}/lib/pkgconfig/openmp.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libiomp5.pc")
+      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libiomp5.pc" "/${compiler_libdir}/" "/lib/intel64/" IGNORE_UNCHANGED)
+      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}" "openmp" "libiomp5")
+    endif()
+endif()
+
+file(COPY_FILE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${main_pc_file}" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/mkl.pc")
+if(NOT VCPKG_BUILD_TYPE)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(GLOB pc_files RELATIVE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/*.pc")
+    foreach(file IN LISTS pc_files)
+      file(COPY_FILE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${file}" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${file}")
+      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${file}" "/include" "/../include")
+      if(NOT VCPKG_TARGET_IS_WINDOWS)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${file}" "/lib/intel64" "/../lib/intel64")
+      endif()
+    endforeach()
+endif()
+
+file(COPY "${mkl_dir}/lib/cmake/" DESTINATION "${CURRENT_PACKAGES_DIR}/share/")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mkl/MKLConfig.cmake" "MKL_CMAKE_PATH}/../../../" "MKL_CMAKE_PATH}/../../")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mkl/MKLConfig.cmake" "redist/\${MKL_ARCH}" "bin")
+if(${VCPKG_LIBRARY_LINKAGE} STREQUAL "static")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mkl/MKLConfig.cmake" "define_param(MKL_LINK DEFAULT_MKL_LINK MKL_LINK_LIST)" 
+[[define_param(MKL_LINK DEFAULT_MKL_LINK MKL_LINK_LIST)
+ set(MKL_LINK "static")
+]])
+endif()
+#TODO: Hardcode settings from portfile in config.cmake
+#TODO: Give lapack/blas information about the correct BLA_VENDOR depending on settings. 
+
+file(INSTALL "${mkl_dir}/licensing" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(GLOB package_path "${extract_0_dir}/packages/intel.oneapi.${package_infix}.mkl.product,v=2023.0.0-*")
+vcpkg_install_copyright(FILE_LIST "${package_path}/licenses/license.htm")
+
+file(REMOVE_RECURSE
+    "${extract_0_dir}"
+    "${extract_1_dir}"
+    "${CURRENT_PACKAGES_DIR}/lib/intel64/cmake"
+    "${CURRENT_PACKAGES_DIR}/lib/intel64/pkgconfig"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/external_ports/intel-mkl/portfile.cmake
+++ b/external_ports/intel-mkl/portfile.cmake
@@ -1,7 +1,7 @@
 # This package installs Intel MKL on Linux, macOS and Windows for x64.
 # Configuration:
-#   - ilp64
-#   - dynamic CRT: intel_thread, static CRT: sequential
+#   - lp64
+#   - sequential
 
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 
@@ -44,13 +44,9 @@ vcpkg_download_distfile(installer_path
 )
 
 # Note: intel_thread and lp64 are the defaults.
-set(interface "ilp64") # or ilp64; ilp == 64 bit int api
+set(interface "lp64") # or ilp64; ilp == 64 bit int api
 #https://www.intel.com/content/www/us/en/develop/documentation/onemkl-linux-developer-guide/top/linking-your-application-with-onemkl/linking-in-detail/linking-with-interface-libraries/using-the-ilp64-interface-vs-lp64-interface.html
-if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
-    set(threading "intel_thread") #sequential or intel_thread or tbb_thread or pgi_thread
-else()
-    set(threading "sequential")
-endif()
+set(threading "sequential")
 if(threading STREQUAL "intel_thread")
     set(short_thread "iomp")
 else()

--- a/external_ports/intel-mkl/usage
+++ b/external_ports/intel-mkl/usage
@@ -1,0 +1,4 @@
+intel-mkl provides CMake targets:
+
+    find_package(MKL CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE MKL::MKL)

--- a/external_ports/intel-mkl/vcpkg.json
+++ b/external_ports/intel-mkl/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "intel-mkl",
+  "version": "2023.0.0",
+  "port-version": 5,
+  "description": "Intel® Math Kernel Library (Intel® MKL) accelerates math processing routines, increases application performance, and reduces development time on Intel® processors.",
+  "homepage": "https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html",
+  "license": null,
+  "supports": "(windows | linux | osx) & x64",
+  "dependencies": [
+    {
+      "name": "vcpkg-tool-lessmsi",
+      "host": true,
+      "platform": "windows"
+    }
+  ]
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,7 +27,7 @@ find_package(Boost REQUIRED)
 
 add_executable(GPRat_test_output_correctness src/output_correctness.cpp)
 target_link_libraries(GPRat_test_output_correctness
-                      PRIVATE GPRat::core Catch2::Catch2WithMain)
+                      PRIVATE GPRat::core Catch2::Catch2WithMain Boost::boost)
 target_compile_features(GPRat_test_output_correctness PRIVATE cxx_std_17)
 
 add_test(

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
+  "overlay-ports": [
+    "./external_ports"
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "gprat",
+  "version-semver": "0.1.0",
+  "dependencies": [
+    {
+      "name": "boost-json"
+    },
+    {
+      "name": "intel-mkl"
+    },
+    {
+      "name": "fmt"
+    },
+    {
+      "name": "hpx"
+    }
+  ],
+  "default-features": [],
+  "builtin-baseline": "e08b7bd89ae162f8579df2f8d39a1ae94107c8fd"
+}


### PR DESCRIPTION
Since `spack` is not available on Windows, this PR adds `vcpkg` as a secondary package manager as well.

It also includes some changes to the code to make it more portable across different operating systems (e.g. not relying on some transitive #includes or non-standard math defines)