### PR TITLE
Fix futures copies and apex compilation

### DIFF
--- a/core/include/apex_utils.hpp
+++ b/core/include/apex_utils.hpp
@@ -1,7 +1,10 @@
 #ifndef APEX_STEPS_H
 #define APEX_STEPS_H
 
+#if GPRAT_APEX_STEPS
 #include <apex_api.hpp>
+#endif
+
 #include <hpx/future.hpp>
 
 /// @brief Alias for obtaining the current high-resolution time point.

--- a/core/include/cpu/adapter_cblas_fp32.hpp
+++ b/core/include/cpu/adapter_cblas_fp32.hpp
@@ -4,6 +4,7 @@
 #include <hpx/future.hpp>
 #include <vector>
 using vector_future = hpx::shared_future<std::vector<float>>;
+using vector = std::vector<float>;
 
 // Constants that are compatible with CBLAS
 typedef enum BLAS_TRANSPOSE { Blas_no_trans = 111, Blas_trans = 112 } BLAS_TRANSPOSE;
@@ -24,9 +25,9 @@ typedef enum BLAS_ALPHA { Blas_add = 1, Blas_substract = -1 } BLAS_ALPHA;
  * @brief FP32 In-place Cholesky decomposition of A
  * @param f_A matrix to be factorized
  * @param N matrix dimension
- * @return factorized, lower triangular matrix f_L
+ * @return factorized, lower triangular matrix L
  */
-vector_future potrf(vector_future f_A, const int N);
+vector potrf(vector_future f_A, const int N);
 
 /**
  * @brief FP32 In-place solve L(^T) * X = A or X * L(^T) = A where L lower triangular
@@ -34,23 +35,23 @@ vector_future potrf(vector_future f_A, const int N);
  * @param f_A right hand side matrix
  * @param N first dimension
  * @param M second dimension
- * @return solution matrix f_X
+ * @return solution matrix X
  */
-vector_future trsm(vector_future f_L,
-                   vector_future f_A,
-                   const int N,
-                   const int M,
-                   const BLAS_TRANSPOSE transpose_L,
-                   const BLAS_SIDE side_L);
+vector trsm(vector_future f_L,
+            vector_future f_A,
+            const int N,
+            const int M,
+            const BLAS_TRANSPOSE transpose_L,
+            const BLAS_SIDE side_L);
 
 /**
  * @brief FP32 Symmetric rank-k update: A = A - B * B^T
  * @param f_A Base matrix
  * @param f_B Symmetric update matrix
  * @param N matrix dimension
- * @return updated matrix f_A
+ * @return updated matrix A
  */
-vector_future syrk(vector_future f_A, vector_future f_B, const int N);
+vector syrk(vector_future f_A, vector_future f_B, const int N);
 
 /**
  * @brief FP32 General matrix-matrix multiplication: C = C - A(^T) * B(^T)
@@ -62,17 +63,16 @@ vector_future syrk(vector_future f_A, vector_future f_B, const int N);
  * @param K third matrix dimension
  * @param transpose_A transpose left matrix
  * @param transpose_B transpose right matrix
- * @return updated matrix f_X
+ * @return updated matrix X
  */
-vector_future
-gemm(vector_future f_A,
-     vector_future f_B,
-     vector_future f_C,
-     const int N,
-     const int M,
-     const int K,
-     const BLAS_TRANSPOSE transpose_A,
-     const BLAS_TRANSPOSE transpose_B);
+vector gemm(vector_future f_A,
+            vector_future f_B,
+            vector_future f_C,
+            const int N,
+            const int M,
+            const int K,
+            const BLAS_TRANSPOSE transpose_A,
+            const BLAS_TRANSPOSE transpose_B);
 
 // BLAS level 2 operations
 
@@ -82,9 +82,9 @@ gemm(vector_future f_A,
  * @param f_a right hand side vector
  * @param N matrix dimension
  * @param transpose_L transpose Cholesky factor
- * @return solution vector f_x
+ * @return solution vector x
  */
-vector_future trsv(vector_future f_L, vector_future f_a, const int N, const BLAS_TRANSPOSE transpose_L);
+vector trsv(vector_future f_L, vector_future f_a, const int N, const BLAS_TRANSPOSE transpose_L);
 
 /**
  * @brief FP32 General matrix-vector multiplication: b = b - A(^T) * a
@@ -94,15 +94,15 @@ vector_future trsv(vector_future f_L, vector_future f_a, const int N, const BLAS
  * @param N matrix dimension
  * @param alpha add or substract update to base vector
  * @param transpose_A transpose update matrix
- * @return updated vector f_b
+ * @return updated vector b
  */
-vector_future gemv(vector_future f_A,
-                   vector_future f_a,
-                   vector_future f_b,
-                   const int N,
-                   const int M,
-                   const BLAS_ALPHA alpha,
-                   const BLAS_TRANSPOSE transpose_A);
+vector gemv(vector_future f_A,
+            vector_future f_a,
+            vector_future f_b,
+            const int N,
+            const int M,
+            const BLAS_ALPHA alpha,
+            const BLAS_TRANSPOSE transpose_A);
 
 /**
  * @brief FP32 Vector update with diagonal SYRK: r = r + diag(A^T * A)
@@ -110,9 +110,9 @@ vector_future gemv(vector_future f_A,
  * @param f_r base vector
  * @param N first matrix dimension
  * @param M second matrix dimension
- * @return updated vector f_r
+ * @return updated vector r
  */
-vector_future dot_diag_syrk(vector_future f_A, vector_future f_r, const int N, const int M);
+vector dot_diag_syrk(vector_future f_A, vector_future f_r, const int N, const int M);
 
 /**
  * @brief FP32 Vector update with diagonal GEMM: r = r + diag(A * B)
@@ -121,9 +121,9 @@ vector_future dot_diag_syrk(vector_future f_A, vector_future f_r, const int N, c
  * @param f_r base vector
  * @param N first matrix dimension
  * @param M second matrix dimension
- * @return updated vector f_r
+ * @return updated vector r
  */
-vector_future dot_diag_gemm(vector_future f_A, vector_future f_B, vector_future f_r, const int N, const int M);
+vector dot_diag_gemm(vector_future f_A, vector_future f_B, vector_future f_r, const int N, const int M);
 
 // BLAS level 1 operations
 
@@ -134,14 +134,14 @@ vector_future dot_diag_gemm(vector_future f_A, vector_future f_B, vector_future 
  * @param N vector length
  * @return y - x
  */
-vector_future axpy(vector_future f_y, vector_future f_x, const int N);
+vector axpy(vector_future f_y, vector_future f_x, const int N);
 
 /**
  * @brief FP32 Dot product: a * b
  * @param f_a left vector
  * @param f_b right vector
  * @param N vector length
- * @return f_a * f_b
+ * @return a * b
  */
 float dot(std::vector<float> a, std::vector<float> b, const int N);
 

--- a/core/include/cpu/adapter_cblas_fp64.hpp
+++ b/core/include/cpu/adapter_cblas_fp64.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 using vector_future = hpx::shared_future<std::vector<double>>;
+using vector = std::vector<double>;
 
 // Constants that are compatible with CBLAS
 
@@ -26,9 +27,9 @@ typedef enum BLAS_ALPHA { Blas_add = 1, Blas_substract = -1 } BLAS_ALPHA;
  * @brief FP64 In-place Cholesky decomposition of A
  * @param f_A matrix to be factorized
  * @param N matrix dimension
- * @return factorized, lower triangular matrix f_L
+ * @return factorized, lower triangular matrix L
  */
-vector_future potrf(vector_future f_A, const int N);
+vector potrf(vector_future f_A, const int N);
 
 /**
  * @brief FP64 In-place solve L(^T) * X = A or X * L(^T) = A where L lower triangular
@@ -36,23 +37,23 @@ vector_future potrf(vector_future f_A, const int N);
  * @param f_A right hand side matrix
  * @param N first dimension
  * @param M second dimension
- * @return solution matrix f_X
+ * @return solution matrix X
  */
-vector_future trsm(vector_future f_L,
-                   vector_future f_A,
-                   const int N,
-                   const int M,
-                   const BLAS_TRANSPOSE transpose_L,
-                   const BLAS_SIDE side_L);
+vector trsm(vector_future f_L,
+            vector_future f_A,
+            const int N,
+            const int M,
+            const BLAS_TRANSPOSE transpose_L,
+            const BLAS_SIDE side_L);
 
 /**
  * @brief FP64 Symmetric rank-k update: A = A - B * B^T
  * @param f_A Base matrix
  * @param f_B Symmetric update matrix
  * @param N matrix dimension
- * @return updated matrix f_A
+ * @return updated matrix A
  */
-vector_future syrk(vector_future f_A, vector_future f_B, const int N);
+vector syrk(vector_future f_A, vector_future f_B, const int N);
 
 /**
  * @brief FP64 General matrix-matrix multiplication: C = C - A(^T) * B(^T)
@@ -64,17 +65,16 @@ vector_future syrk(vector_future f_A, vector_future f_B, const int N);
  * @param K third matrix dimension
  * @param transpose_A transpose left matrix
  * @param transpose_B transpose right matrix
- * @return updated matrix f_X
+ * @return updated matrix X
  */
-vector_future
-gemm(vector_future f_A,
-     vector_future f_B,
-     vector_future f_C,
-     const int N,
-     const int M,
-     const int K,
-     const BLAS_TRANSPOSE transpose_A,
-     const BLAS_TRANSPOSE transpose_B);
+vector gemm(vector_future f_A,
+            vector_future f_B,
+            vector_future f_C,
+            const int N,
+            const int M,
+            const int K,
+            const BLAS_TRANSPOSE transpose_A,
+            const BLAS_TRANSPOSE transpose_B);
 
 // BLAS level 2 operations
 
@@ -84,9 +84,9 @@ gemm(vector_future f_A,
  * @param f_a right hand side vector
  * @param N matrix dimension
  * @param transpose_L transpose Cholesky factor
- * @return solution vector f_x
+ * @return solution vector x
  */
-vector_future trsv(vector_future f_L, vector_future f_a, const int N, const BLAS_TRANSPOSE transpose_L);
+vector trsv(vector_future f_L, vector_future f_a, const int N, const BLAS_TRANSPOSE transpose_L);
 
 /**
  * @brief FP64 General matrix-vector multiplication: b = b - A(^T) * a
@@ -96,15 +96,15 @@ vector_future trsv(vector_future f_L, vector_future f_a, const int N, const BLAS
  * @param N matrix dimension
  * @param alpha add or substract update to base vector
  * @param transpose_A transpose update matrix
- * @return updated vector f_b
+ * @return updated vector b
  */
-vector_future gemv(vector_future f_A,
-                   vector_future f_a,
-                   vector_future f_b,
-                   const int N,
-                   const int M,
-                   const BLAS_ALPHA alpha,
-                   const BLAS_TRANSPOSE transpose_A);
+vector gemv(vector_future f_A,
+            vector_future f_a,
+            vector_future f_b,
+            const int N,
+            const int M,
+            const BLAS_ALPHA alpha,
+            const BLAS_TRANSPOSE transpose_A);
 
 /**
  * @brief FP64 Vector update with diagonal SYRK: r = r + diag(A^T * A)
@@ -112,9 +112,9 @@ vector_future gemv(vector_future f_A,
  * @param f_r base vector
  * @param N first matrix dimension
  * @param M second matrix dimension
- * @return updated vector f_r
+ * @return updated vector r
  */
-vector_future dot_diag_syrk(vector_future f_A, vector_future f_r, const int N, const int M);
+vector dot_diag_syrk(vector_future f_A, vector_future f_r, const int N, const int M);
 
 /**
  * @brief FP64 Vector update with diagonal GEMM: r = r + diag(A * B)
@@ -123,9 +123,9 @@ vector_future dot_diag_syrk(vector_future f_A, vector_future f_r, const int N, c
  * @param f_r base vector
  * @param N first matrix dimension
  * @param M second matrix dimension
- * @return updated vector f_r
+ * @return updated vector r
  */
-vector_future dot_diag_gemm(vector_future f_A, vector_future f_B, vector_future f_r, const int N, const int M);
+vector dot_diag_gemm(vector_future f_A, vector_future f_B, vector_future f_r, const int N, const int M);
 
 // BLAS level 1 operations
 
@@ -136,7 +136,7 @@ vector_future dot_diag_gemm(vector_future f_A, vector_future f_B, vector_future 
  * @param N vector length
  * @return y - x
  */
-vector_future axpy(vector_future f_y, vector_future f_x, const int N);
+vector axpy(vector_future f_y, vector_future f_x, const int N);
 
 /**
  * @brief FP64 Dot product: a * b

--- a/core/src/cpu/adapter_cblas_fp32.cpp
+++ b/core/src/cpu/adapter_cblas_fp32.cpp
@@ -11,26 +11,26 @@
 
 // BLAS level 3 operations
 
-vector_future potrf(vector_future f_A, const int N)
+vector potrf(vector_future f_A, const int N)
 {
-    auto A = f_A.get();
+    vector A = f_A.get();
     // POTRF: in-place Cholesky decomposition of A
     // use spotrf2 recursive version for better stability
     LAPACKE_spotrf2(LAPACK_ROW_MAJOR, 'L', N, A.data(), N);
     // return factorized matrix L
-    return hpx::make_ready_future(A);
+    return A;
 }
 
-vector_future trsm(vector_future f_L,
-                   vector_future f_A,
-                   const int N,
-                   const int M,
-                   const BLAS_TRANSPOSE transpose_L,
-                   const BLAS_SIDE side_L)
+vector trsm(vector_future f_L,
+            vector_future f_A,
+            const int N,
+            const int M,
+            const BLAS_TRANSPOSE transpose_L,
+            const BLAS_SIDE side_L)
 
 {
-    auto L = f_L.get();
-    auto A = f_A.get();
+    const vector &L = f_L.get();
+    vector A = f_A.get();
     // TRSM constants
     const float alpha = 1.0;
     // TRSM: in-place solve L(^T) * X = A or X * L(^T) = A where L lower triangular
@@ -48,35 +48,34 @@ vector_future trsm(vector_future f_L,
         A.data(),
         M);
     // return vector
-    return hpx::make_ready_future(A);
+    return A;
 }
 
-vector_future syrk(vector_future f_A, vector_future f_B, const int N)
+vector syrk(vector_future f_A, vector_future f_B, const int N)
 {
-    auto B = f_B.get();
-    auto A = f_A.get();
+    const vector &B = f_B.get();
+    vector A = f_A.get();
     // SYRK constants
     const float alpha = -1.0;
     const float beta = 1.0;
     // SYRK:A = A - B * B^T
     cblas_ssyrk(CblasRowMajor, CblasLower, CblasNoTrans, N, N, alpha, B.data(), N, beta, A.data(), N);
     // return updated matrix A
-    return hpx::make_ready_future(A);
+    return A;
 }
 
-vector_future
-gemm(vector_future f_A,
-     vector_future f_B,
-     vector_future f_C,
-     const int N,
-     const int M,
-     const int K,
-     const BLAS_TRANSPOSE transpose_A,
-     const BLAS_TRANSPOSE transpose_B)
+vector gemm(vector_future f_A,
+            vector_future f_B,
+            vector_future f_C,
+            const int N,
+            const int M,
+            const int K,
+            const BLAS_TRANSPOSE transpose_A,
+            const BLAS_TRANSPOSE transpose_B)
 {
-    auto C = f_C.get();
-    auto B = f_B.get();
-    auto A = f_A.get();
+    vector C = f_C.get();
+    const vector &B = f_B.get();
+    const vector &A = f_A.get();
     // GEMM constants
     const float alpha = -1.0;
     const float beta = 1.0;
@@ -97,15 +96,15 @@ gemm(vector_future f_A,
         C.data(),
         M);
     // return updated matrix C
-    return hpx::make_ready_future(C);
+    return C;
 }
 
 // BLAS level 2 operations
 
-vector_future trsv(vector_future f_L, vector_future f_a, const int N, const BLAS_TRANSPOSE transpose_L)
+vector trsv(vector_future f_L, vector_future f_a, const int N, const BLAS_TRANSPOSE transpose_L)
 {
-    auto L = f_L.get();
-    auto a = f_a.get();
+    const vector &L = f_L.get();
+    vector a = f_a.get();
     // TRSV: In-place solve L(^T) * x = a where L lower triangular
     cblas_strsv(CblasRowMajor,
                 CblasLower,
@@ -117,20 +116,20 @@ vector_future trsv(vector_future f_L, vector_future f_a, const int N, const BLAS
                 a.data(),
                 1);
     // return solution vector x
-    return hpx::make_ready_future(a);
+    return a;
 }
 
-vector_future gemv(vector_future f_A,
-                   vector_future f_a,
-                   vector_future f_b,
-                   const int N,
-                   const int M,
-                   const BLAS_ALPHA alpha,
-                   const BLAS_TRANSPOSE transpose_A)
+vector gemv(vector_future f_A,
+            vector_future f_a,
+            vector_future f_b,
+            const int N,
+            const int M,
+            const BLAS_ALPHA alpha,
+            const BLAS_TRANSPOSE transpose_A)
 {
-    auto A = f_A.get();
-    auto a = f_a.get();
-    auto b = f_b.get();
+    const vector &A = f_A.get();
+    const vector &a = f_a.get();
+    vector b = f_b.get();
     // GEMV constants
     // const float alpha = -1.0;
     const float beta = 1.0;
@@ -149,46 +148,46 @@ vector_future gemv(vector_future f_A,
         b.data(),
         1);
     // return updated vector b
-    return hpx::make_ready_future(b);
+    return b;
 }
 
-vector_future dot_diag_syrk(vector_future f_A, vector_future f_r, const int N, const int M)
+vector dot_diag_syrk(vector_future f_A, vector_future f_r, const int N, const int M)
 {
-    auto A = f_A.get();
-    auto r = f_r.get();
+    const vector &A = f_A.get();
+    vector r = f_r.get();
     // r = r + diag(A^T * A)
     for (std::size_t j = 0; j < static_cast<std::size_t>(M); ++j)
     {
         // Extract the j-th column and compute the dot product with itself
         r[j] += cblas_sdot(N, &A[j], M, &A[j], M);
     }
-    return hpx::make_ready_future(r);
+    return r;
 }
 
-vector_future dot_diag_gemm(vector_future f_A, vector_future f_B, vector_future f_r, const int N, const int M)
+vector dot_diag_gemm(vector_future f_A, vector_future f_B, vector_future f_r, const int N, const int M)
 {
-    auto A = f_A.get();
-    auto B = f_B.get();
-    auto r = f_r.get();
+    const vector &A = f_A.get();
+    const vector &B = f_B.get();
+    vector r = f_r.get();
     // r = r + diag(A * B)
     for (std::size_t i = 0; i < static_cast<std::size_t>(N); ++i)
     {
         r[i] += cblas_sdot(M, &A[i * static_cast<std::size_t>(M)], 1, &B[i], N);
     }
-    return hpx::make_ready_future(r);
+    return r;
 }
 
 // BLAS level 1 operations
 
-vector_future axpy(vector_future f_y, vector_future f_x, const int N)
+vector axpy(vector_future f_y, vector_future f_x, const int N)
 {
-    auto y = f_y.get();
-    auto x = f_x.get();
+    vector y = f_y.get();
+    const vector &x = f_x.get();
     cblas_saxpy(N, -1.0, x.data(), 1, y.data(), 1);
-    return hpx::make_ready_future(y);
+    return y;
 }
 
-float dot(std::vector<float> a, std::vector<float> b, const int N)
+float dot(vector a, vector b, const int N)
 {
     // DOT: a * b
     return cblas_sdot(N, a.data(), 1, b.data(), 1);

--- a/core/src/cpu/adapter_cblas_fp64.cpp
+++ b/core/src/cpu/adapter_cblas_fp64.cpp
@@ -11,26 +11,26 @@
 
 // BLAS level 3 operations
 
-vector_future potrf(vector_future f_A, const int N)
+vector potrf(vector_future f_A, const int N)
 {
-    auto A = f_A.get();
+    vector A = f_A.get();
     // POTRF: in-place Cholesky decomposition of A
     // use dpotrf2 recursive version for better stability
     LAPACKE_dpotrf2(LAPACK_ROW_MAJOR, 'L', N, A.data(), N);
     // return factorized matrix L
-    return hpx::make_ready_future(A);
+    return A;
 }
 
-vector_future trsm(vector_future f_L,
-                   vector_future f_A,
-                   const int N,
-                   const int M,
-                   const BLAS_TRANSPOSE transpose_L,
-                   const BLAS_SIDE side_L)
+vector trsm(vector_future f_L,
+            vector_future f_A,
+            const int N,
+            const int M,
+            const BLAS_TRANSPOSE transpose_L,
+            const BLAS_SIDE side_L)
 
 {
-    auto L = f_L.get();
-    auto A = f_A.get();
+    const vector &L = f_L.get();
+    vector A = f_A.get();
     // TRSM constants
     const double alpha = 1.0;
     // TRSM: in-place solve L(^T) * X = A or X * L(^T) = A where L lower triangular
@@ -48,35 +48,34 @@ vector_future trsm(vector_future f_L,
         A.data(),
         M);
     // return vector
-    return hpx::make_ready_future(A);
+    return A;
 }
 
-vector_future syrk(vector_future f_A, vector_future f_B, const int N)
+vector syrk(vector_future f_A, vector_future f_B, const int N)
 {
-    auto B = f_B.get();
-    auto A = f_A.get();
+    const vector &B = f_B.get();
+    vector A = f_A.get();
     // SYRK constants
     const double alpha = -1.0;
     const double beta = 1.0;
     // SYRK:A = A - B * B^T
     cblas_dsyrk(CblasRowMajor, CblasLower, CblasNoTrans, N, N, alpha, B.data(), N, beta, A.data(), N);
     // return updated matrix A
-    return hpx::make_ready_future(A);
+    return A;
 }
 
-vector_future
-gemm(vector_future f_A,
-     vector_future f_B,
-     vector_future f_C,
-     const int N,
-     const int M,
-     const int K,
-     const BLAS_TRANSPOSE transpose_A,
-     const BLAS_TRANSPOSE transpose_B)
+vector gemm(vector_future f_A,
+            vector_future f_B,
+            vector_future f_C,
+            const int N,
+            const int M,
+            const int K,
+            const BLAS_TRANSPOSE transpose_A,
+            const BLAS_TRANSPOSE transpose_B)
 {
-    auto C = f_C.get();
-    auto B = f_B.get();
-    auto A = f_A.get();
+    vector C = f_C.get();
+    const vector &B = f_B.get();
+    const vector &A = f_A.get();
     // GEMM constants
     const double alpha = -1.0;
     const double beta = 1.0;
@@ -97,15 +96,15 @@ gemm(vector_future f_A,
         C.data(),
         M);
     // return updated matrix C
-    return hpx::make_ready_future(C);
+    return C;
 }
 
 // BLAS level 2 operations
 
-vector_future trsv(vector_future f_L, vector_future f_a, const int N, const BLAS_TRANSPOSE transpose_L)
+vector trsv(vector_future f_L, vector_future f_a, const int N, const BLAS_TRANSPOSE transpose_L)
 {
-    auto L = f_L.get();
-    auto a = f_a.get();
+    const vector &L = f_L.get();
+    vector a = f_a.get();
     // TRSV: In-place solve L(^T) * x = a where L lower triangular
     cblas_dtrsv(CblasRowMajor,
                 CblasLower,
@@ -117,20 +116,20 @@ vector_future trsv(vector_future f_L, vector_future f_a, const int N, const BLAS
                 a.data(),
                 1);
     // return solution vector x
-    return hpx::make_ready_future(a);
+    return a;
 }
 
-vector_future gemv(vector_future f_A,
-                   vector_future f_a,
-                   vector_future f_b,
-                   const int N,
-                   const int M,
-                   const BLAS_ALPHA alpha,
-                   const BLAS_TRANSPOSE transpose_A)
+vector gemv(vector_future f_A,
+            vector_future f_a,
+            vector_future f_b,
+            const int N,
+            const int M,
+            const BLAS_ALPHA alpha,
+            const BLAS_TRANSPOSE transpose_A)
 {
-    auto A = f_A.get();
-    auto a = f_a.get();
-    auto b = f_b.get();
+    const vector &A = f_A.get();
+    const vector &a = f_a.get();
+    vector b = f_b.get();
     // GEMV constants
     // const double alpha = -1.0;
     const double beta = 1.0;
@@ -149,43 +148,43 @@ vector_future gemv(vector_future f_A,
         b.data(),
         1);
     // return updated vector b
-    return hpx::make_ready_future(b);
+    return b;
 }
 
-vector_future dot_diag_syrk(vector_future f_A, vector_future f_r, const int N, const int M)
+vector dot_diag_syrk(vector_future f_A, vector_future f_r, const int N, const int M)
 {
-    auto A = f_A.get();
-    auto r = f_r.get();
+    const vector &A = f_A.get();
+    vector r = f_r.get();
     // r = r + diag(A^T * A)
     for (std::size_t j = 0; j < static_cast<std::size_t>(M); ++j)
     {
         // Extract the j-th column and compute the dot product with itself
         r[j] += cblas_ddot(N, &A[j], M, &A[j], M);
     }
-    return hpx::make_ready_future(r);
+    return r;
 }
 
-vector_future dot_diag_gemm(vector_future f_A, vector_future f_B, vector_future f_r, const int N, const int M)
+vector dot_diag_gemm(vector_future f_A, vector_future f_B, vector_future f_r, const int N, const int M)
 {
-    auto A = f_A.get();
-    auto B = f_B.get();
-    auto r = f_r.get();
+    const vector &A = f_A.get();
+    const vector &B = f_B.get();
+    vector r = f_r.get();
     // r = r + diag(A * B)
     for (std::size_t i = 0; i < static_cast<std::size_t>(N); ++i)
     {
         r[i] += cblas_ddot(M, &A[i * static_cast<std::size_t>(M)], 1, &B[i], N);
     }
-    return hpx::make_ready_future(r);
+    return r;
 }
 
 // BLAS level 1 operations
 
-vector_future axpy(vector_future f_y, vector_future f_x, const int N)
+vector axpy(vector_future f_y, vector_future f_x, const int N)
 {
-    auto y = f_y.get();
-    auto x = f_x.get();
+    vector y = f_y.get();
+    const vector &x = f_x.get();
     cblas_daxpy(N, -1.0, x.data(), 1, y.data(), 1);
-    return hpx::make_ready_future(y);
+    return y;
 }
 
 double dot(std::vector<double> a, std::vector<double> b, const int N)


### PR DESCRIPTION
Content:
- Fix compilation of GPRat when HPX was not compiled with APEX
- Fix redundant tiles copies induced by `auto` type when retrieving shared futures